### PR TITLE
RetrieveAssertionInfo(): indicate what elements have validated signatures

### DIFF
--- a/retrieve_assertion.go
+++ b/retrieve_assertion.go
@@ -49,6 +49,7 @@ func (sp *SAMLServiceProvider) RetrieveAssertionInfo(encodedResponse string) (*A
 
 	assertion := response.Assertions[0]
 	assertionInfo.Assertions = response.Assertions
+	assertionInfo.ResponseSignatureValidated = response.SignatureValidated
 
 	warningInfo, err := sp.VerifyAssertionConditions(&assertion)
 	if err != nil {

--- a/saml.go
+++ b/saml.go
@@ -184,10 +184,11 @@ type WarningInfo struct {
 }
 
 type AssertionInfo struct {
-	NameID              string
-	Values              Values
-	WarningInfo         *WarningInfo
-	AuthnInstant        *time.Time
-	SessionNotOnOrAfter *time.Time
-	Assertions          []types.Assertion
+	NameID                     string
+	Values                     Values
+	WarningInfo                *WarningInfo
+	AuthnInstant               *time.Time
+	SessionNotOnOrAfter        *time.Time
+	Assertions                 []types.Assertion
+	ResponseSignatureValidated bool
 }

--- a/types/response.go
+++ b/types/response.go
@@ -16,6 +16,7 @@ type Response struct {
 	Issuer              *Issuer              `xml:"Issuer"`
 	Assertions          []Assertion          `xml:"Assertion"`
 	EncryptedAssertions []EncryptedAssertion `xml:"EncryptedAssertion"`
+	SignatureValidated  bool                 `xml:"-"` // not read, not dumped
 }
 
 type Status struct {
@@ -48,6 +49,7 @@ type Assertion struct {
 	Conditions         *Conditions         `xml:"Conditions"`
 	AttributeStatement *AttributeStatement `xml:"AttributeStatement"`
 	AuthnStatement     *AuthnStatement     `xml:"AuthnStatement"`
+	SignatureValidated bool                `xml:"-"` // not read, not dumped
 }
 
 type Subject struct {


### PR DESCRIPTION
@rsrsps ,

1) When Okta is told to **not** encrypt the Assertion, but to sign both 
Response and Assertion, it only signs the Response.

2) When Okta is told to encrypt the Assertion, but to sign both 
Response and Assertion, it only signs **both** the Response and Assertion

It was impossible to tell if the Assertion was signed in case '2' by looking only
at the Response XML and the library was giving no indication either.
These changes make it so the library sets some booleans to indicate this.

