### PR TITLE
support signed AuthnRequest with HTTP-Redirect binding

### DIFF
--- a/build_request.go
+++ b/build_request.go
@@ -14,7 +14,7 @@ import (
 
 const issueInstantFormat = "2006-01-02T15:04:05Z"
 
-func (sp *SAMLServiceProvider) BuildAuthRequestDocument() (*etree.Document, error) {
+func (sp *SAMLServiceProvider) buildAuthnRequest(includeSig bool) (*etree.Document, error) {
 	authnRequest := &etree.Element{
 		Space: "samlp",
 		Tag:   "AuthnRequest",
@@ -55,7 +55,8 @@ func (sp *SAMLServiceProvider) BuildAuthRequestDocument() (*etree.Document, erro
 
 	doc := etree.NewDocument()
 
-	if sp.SignAuthnRequests {
+	// Only POST binding includes <Signature> in <AuthnRequest> (includeSig)
+	if sp.SignAuthnRequests && includeSig {
 		signed, err := sp.SignAuthnRequest(authnRequest)
 		if err != nil {
 			return nil, err
@@ -66,6 +67,14 @@ func (sp *SAMLServiceProvider) BuildAuthRequestDocument() (*etree.Document, erro
 		doc.SetRoot(authnRequest)
 	}
 	return doc, nil
+}
+
+func (sp *SAMLServiceProvider) BuildAuthRequestDocument() (*etree.Document, error) {
+	return sp.buildAuthnRequest(true)
+}
+
+func (sp *SAMLServiceProvider) BuildAuthRequestDocumentNoSig() (*etree.Document, error) {
+	return sp.buildAuthnRequest(false)
 }
 
 // SignAuthnRequest takes a document, builds a signature, creates another document
@@ -101,7 +110,7 @@ func (sp *SAMLServiceProvider) BuildAuthRequest() (string, error) {
 	return doc.WriteToString()
 }
 
-func (sp *SAMLServiceProvider) BuildAuthURLFromDocument(relayState string, doc *etree.Document) (string, error) {
+func (sp *SAMLServiceProvider) buildAuthURLFromDocument(relayState, binding string, doc *etree.Document) (string, error) {
 	parsedUrl, err := url.Parse(sp.IdentityProviderSSOURL)
 	if err != nil {
 		return "", err
@@ -137,8 +146,29 @@ func (sp *SAMLServiceProvider) BuildAuthURLFromDocument(relayState string, doc *
 		qs.Add("RelayState", relayState)
 	}
 
+	if sp.SignAuthnRequests && binding == BindingHttpRedirect {
+		// Sign URL encoded query (see Section 3.4.4.1 DEFLATE Encoding of saml-bindings-2.0-os.pdf)
+		ctx := sp.SigningContext()
+		qs.Add("SigAlg", ctx.GetSignatureMethodIdentifier())
+		var rawSignature []byte
+		if rawSignature, err = ctx.SignString(qs.Encode()); err != nil {
+			return "", fmt.Errorf("unable to sign query string of redirect URL: %v", err)
+		}
+
+		// Now add base64 encoded Signature
+		qs.Add("Signature", base64.StdEncoding.EncodeToString(rawSignature))
+	}
+
 	parsedUrl.RawQuery = qs.Encode()
 	return parsedUrl.String(), nil
+}
+
+func (sp *SAMLServiceProvider) BuildAuthURLFromDocument(relayState string, doc *etree.Document) (string, error) {
+	return sp.buildAuthURLFromDocument(relayState, BindingHttpPost, doc)
+}
+
+func (sp *SAMLServiceProvider) BuildAuthURLRedirect(relayState string, doc *etree.Document) (string, error) {
+	return sp.buildAuthURLFromDocument(relayState, BindingHttpRedirect, doc)
 }
 
 // BuildAuthURL builds redirect URL to be sent to principal


### PR DESCRIPTION
@ben-skyportsystems , these changes depend on [goxmldsig/pull/31](https://github.com/russellhaering/goxmldsig/pull/31).
Now that [goxmldsig/pull/31](https://github.com/russellhaering/goxmldsig/pull/31) has been merged into russellhaering/goxmldsig master,
I can now merge the changes here into skyportsystems/gosaml2 master and not break
continuous integration tests performed on [russellhaering/gosaml2/pull/33](https://github.com/russellhaering/gosaml2/pull/33).
Please approve and I will merge and follow up with russellhaering.

