### PR TITLE
SPS-8930: fix skyportsystems/gosaml2 to work with latest russellhaering/goxmldsig and satori/go.uuid

### DIFF
--- a/build_request.go
+++ b/build_request.go
@@ -23,7 +23,11 @@ func (sp *SAMLServiceProvider) buildAuthnRequest(includeSig bool) (*etree.Docume
 	authnRequest.CreateAttr("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
 	authnRequest.CreateAttr("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion")
 
-	authnRequest.CreateAttr("ID", "_"+uuid.NewV4().String())
+	arId, uerr := uuid.NewV4()
+	if uerr != nil {
+		return nil, fmt.Errorf("unable to create UUID: %v", uerr)
+	}
+	authnRequest.CreateAttr("ID", "_"+arId.String())
 	authnRequest.CreateAttr("Version", "2.0")
 	authnRequest.CreateAttr("ProtocolBinding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")
 	authnRequest.CreateAttr("AssertionConsumerServiceURL", sp.AssertionConsumerServiceURL)

--- a/saml.go
+++ b/saml.go
@@ -88,9 +88,9 @@ func (sp *SAMLServiceProvider) Metadata() (*types.EntityDescriptor, error) {
 					Use: "signing",
 					KeyInfo: dsigtypes.KeyInfo{
 						X509Data: dsigtypes.X509Data{
-							X509Certificate: dsigtypes.X509Certificate{
+							X509Certificates: []dsigtypes.X509Certificate{dsigtypes.X509Certificate{
 								Data: base64.StdEncoding.EncodeToString(signingCertBytes),
-							},
+							}},
 						},
 					},
 				},
@@ -98,9 +98,9 @@ func (sp *SAMLServiceProvider) Metadata() (*types.EntityDescriptor, error) {
 					Use: "encryption",
 					KeyInfo: dsigtypes.KeyInfo{
 						X509Data: dsigtypes.X509Data{
-							X509Certificate: dsigtypes.X509Certificate{
+							X509Certificates: []dsigtypes.X509Certificate{dsigtypes.X509Certificate{
 								Data: base64.StdEncoding.EncodeToString(encryptionCertBytes),
-							},
+							}},
 						},
 					},
 					EncryptionMethods: []types.EncryptionMethod{


### PR DESCRIPTION
@ben-skyportsystems , in preparation for [gosaml2/pull/33](https://github.com/russellhaering/gosaml2/pull/33),
I found that the master branches of [russellhaering/goxmldsig](https://github.com/russellhaering/goxmldsig) and [satori/go.uuid](https://github.com/satori/go.uuid)
moved along and [gosaml2/pull/33](https://github.com/russellhaering/gosaml2/pull/33) no longer passed travis continuous integration testing.

I found that the changes to both [russellhaering/goxmldsig](https://github.com/russellhaering/goxmldsig) and [satori/go.uuid](https://github.com/satori/go.uuid) were reasonable.

I was able to reproduce both problems and fix them in this pull request.
Once you approve these, I'll merge these changes into
the master branch of [skyportsystems/gosaml2](https://github.com/skyportsystems/gosaml2).
At that time, [gosaml2/pull/33](https://github.com/russellhaering/gosaml2/pull/33) _**should**_ go
back to being green (passing travis tests).

I'll also update go_repos.json for the sc-minipoc build and run smoke to
make sure I didn't break anything in SSC.

Thanks,
Paul

